### PR TITLE
BC: payload (former workData) always passed as message

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ console.log(myExpensiveFunction);
 My worker:
 ```js
 const { parentPort, workerData } = require('worker_threads');
-// Do some expensive stuff
-myOutput = workerData.map((item) => item * 2);
-parentPort.postMessage(myOutput);
+parentPort.on('message', (input) => {
+  // Do some expensive stuff
+  myOutput = input.map((item) => item * 2);
+  parentPort.postMessage(myOutput);
+});
 ```
 
 ## Advanced usage - Preloading
@@ -56,9 +58,7 @@ parentPort.on('message', (input) => {
 
 The workerThreadExecute function takes two arguments:
 - `workerPathOrInstance`(_required_): Either a path to a worker file or a preloaded worker instance.  
-- `workerData`(_optional_): The input to be passed to the worker. Please be aware the input will work differently depending on the type of the worker.  
-  - If the worker is a preloaded worker, the input will be passed to the worker as a message.  
-  - If the worker is a path to a worker file, the input will be passed to the worker as a parameter available using the `workerData` property of the `worker_threads` module.
+- `payload`(_optional_): The input to be passed to the worker. The input will be passed to the worker as a message.  
 - `options`(_optional_): An object containing the following properties:
   - `unref`: If set to `true`, the worker thread will be unref'd. Defaults to `false`.  
   - `timeout`: The timeout in milliseconds after which the worker will be terminated. Defaults to `0` (no timeout).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ console.log(myExpensiveFunction);
 
 My worker:
 ```js
-const { parentPort, workerData } = require('worker_threads');
+const { parentPort } = require('worker_threads');
 parentPort.on('message', (input) => {
   // Do some expensive stuff
   myOutput = input.map((item) => item * 2);
@@ -58,7 +58,7 @@ parentPort.on('message', (input) => {
 
 The workerThreadExecute function takes two arguments:
 - `workerPathOrInstance`(_required_): Either a path to a worker file or a preloaded worker instance.  
-- `payload`(_optional_): The input to be passed to the worker. The input will be passed to the worker as a message.  
+- `payload`(_optional_): The input to be passed to the worker. This input will be passed to the worker as a message.  
 - `options`(_optional_): An object containing the following properties:
   - `unref`: If set to `true`, the worker thread will be unref'd. Defaults to `false`.  
   - `timeout`: The timeout in milliseconds after which the worker will be terminated. Defaults to `0` (no timeout).

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,26 +3,54 @@ import { workerThreadExecute } from './lib';
 
 it('should call the worker when path is given', async () => {
   const result = await workerThreadExecute(
-    `${process.cwd()}/src/tests/worker-without-postmessage.mjs`,
+    `${process.cwd()}/src/tests/worker-sample.mjs`,
     1,
-    { unref: true }
+    { unref: true, timeout: 500 }
   );
   expect(result).toBe(2);
 });
 
-it('should call the worker when preloaded', async () => {
+it('should work without a payload', async () => {
+  const result = await workerThreadExecute(
+    `${process.cwd()}/src/tests/worker-sample.mjs`,
+    undefined,
+    { unref: true, timeout: 500  }
+  );
+  
+  expect(result).toBeNaN();
+
   const worker = new Worker(
-    `${process.cwd()}/src/tests/worker-with-postmessage.mjs`
+    `${process.cwd()}/src/tests/worker-sample.mjs`
   );
   worker.unref();
-  const result = await workerThreadExecute(worker, 1);
+  const resultWithPreload = await workerThreadExecute(worker, 1, { timeout: 500 });
+  expect(resultWithPreload).toBe(2);
+  worker.terminate();
+});
+
+it('should call the worker when preloaded', async () => {
+  const worker = new Worker(
+    `${process.cwd()}/src/tests/worker-sample.mjs`
+  );
+  worker.unref();
+  const result = await workerThreadExecute(worker, 1, { timeout: 500 });
   expect(result).toBe(2);
+  worker.terminate();
+});
+
+it('should work without passing options', async () => {
+  const worker = new Worker(
+    `${process.cwd()}/src/tests/worker-sample.mjs`
+  );
+  worker.unref();
+  const result = await workerThreadExecute(worker);
+  expect(result).toBeNaN();
   worker.terminate();
 });
 
 it('should throw if the worker exceeds given timeout', async () => {
   try {
-    const result = await workerThreadExecute(
+    await workerThreadExecute(
       `${process.cwd()}/src/tests/worker-with-delay.mjs`,
       1,
       { timeout: 10, unref: true }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -14,24 +14,22 @@ it('should work without a payload', async () => {
   const result = await workerThreadExecute(
     `${process.cwd()}/src/tests/worker-sample.mjs`,
     undefined,
-    { unref: true, timeout: 500  }
+    { unref: true, timeout: 500 }
   );
-  
+
   expect(result).toBeNaN();
 
-  const worker = new Worker(
-    `${process.cwd()}/src/tests/worker-sample.mjs`
-  );
+  const worker = new Worker(`${process.cwd()}/src/tests/worker-sample.mjs`);
   worker.unref();
-  const resultWithPreload = await workerThreadExecute(worker, 1, { timeout: 500 });
+  const resultWithPreload = await workerThreadExecute(worker, 1, {
+    timeout: 500
+  });
   expect(resultWithPreload).toBe(2);
   worker.terminate();
 });
 
 it('should call the worker when preloaded', async () => {
-  const worker = new Worker(
-    `${process.cwd()}/src/tests/worker-sample.mjs`
-  );
+  const worker = new Worker(`${process.cwd()}/src/tests/worker-sample.mjs`);
   worker.unref();
   const result = await workerThreadExecute(worker, 1, { timeout: 500 });
   expect(result).toBe(2);
@@ -39,9 +37,7 @@ it('should call the worker when preloaded', async () => {
 });
 
 it('should work without passing options', async () => {
-  const worker = new Worker(
-    `${process.cwd()}/src/tests/worker-sample.mjs`
-  );
+  const worker = new Worker(`${process.cwd()}/src/tests/worker-sample.mjs`);
   worker.unref();
   const result = await workerThreadExecute(worker);
   expect(result).toBeNaN();

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,10 +1,10 @@
-import { Worker } from 'worker_threads';
+import { Worker, WorkerOptions } from 'worker_threads';
 import { defaultOptions } from './defaults';
 import { Options } from './models';
 
 export function workerThreadExecute<T>(
   workerPathOrInstance: string | Worker,
-  workerData: unknown = undefined,
+  payload: unknown = undefined,
   _options: Partial<Options> = {},
   workerOptions: WorkerOptions = {}
 ): Promise<T> {
@@ -15,14 +15,11 @@ export function workerThreadExecute<T>(
     };
     let worker: string | Worker;
     if (typeof workerPathOrInstance === 'string') {
-      worker = new Worker(workerPathOrInstance, {
-        workerData,
-        ...workerOptions
-      });
+      worker = new Worker(workerPathOrInstance, workerOptions);
     } else {
       worker = workerPathOrInstance;
-      worker.postMessage(workerData);
     }
+    worker.postMessage(payload);
     if (options.unref) {
       worker.unref();
     }

--- a/src/tests/worker-sample.mjs
+++ b/src/tests/worker-sample.mjs
@@ -1,11 +1,6 @@
 import { parentPort } from 'worker_threads';
 if (parentPort) {
-  // A fake expensive operation
-  const start = Date.now();
-  while (Date.now() - start < 1000) {
-    return;
-  }
   parentPort.on('message', (payload) => {
     parentPort.postMessage(payload * 2);
-  })
+  });
 }

--- a/src/tests/worker-with-delay.mjs
+++ b/src/tests/worker-with-delay.mjs
@@ -7,5 +7,5 @@ if (parentPort) {
   }
   parentPort.on('message', (payload) => {
     parentPort.postMessage(payload * 2);
-  })
+  });
 }

--- a/src/tests/worker-with-postmessage.mjs
+++ b/src/tests/worker-with-postmessage.mjs
@@ -1,6 +1,0 @@
-import { parentPort } from 'worker_threads';
-if (parentPort) {
-  parentPort.on('message', (workerData) => {
-    parentPort.postMessage(workerData * 2);
-  });
-}

--- a/src/tests/worker-without-postmessage.mjs
+++ b/src/tests/worker-without-postmessage.mjs
@@ -1,4 +1,0 @@
-import { workerData, parentPort } from 'worker_threads';
-if (parentPort) {
-  parentPort.postMessage(workerData * 2);
-}


### PR DESCRIPTION
As per title, the proposed change will uniformate how the function `workerThreadExecute` will use the passed `payload` (former `workData`). With those changes, regardeless of the initialization mode, the payload will be passed to the worker always as a message.